### PR TITLE
Fix compile errors with current http-conduit (1.9.2.2)

### DIFF
--- a/src/Network/Api/Support/Core.hs
+++ b/src/Network/Api/Support/Core.hs
@@ -44,7 +44,7 @@ runRequest' ::
   -> m b
 runRequest' settings url transform responder =
   do url' <- parseUrl $ unpack url
-     let url'' = url' { checkStatus = const . const $ Nothing } -- handle all response codes.
+     let url'' = url' { checkStatus = const . const . const $ Nothing } -- handle all response codes.
      let req = appEndo transform url''
      liftM (responder req) . withCustomManager settings . httpLbs $ req
 

--- a/src/Network/Api/Support/Request.hs
+++ b/src/Network/Api/Support/Request.hs
@@ -25,6 +25,7 @@ import Data.Monoid
 import Data.Time
 
 import Network.HTTP.Conduit
+import Network.HTTP.Conduit.Internal (insertCookiesIntoRequest)
 
 -- * Request transformers
 

--- a/src/Network/Api/Support/Response.hs
+++ b/src/Network/Api/Support/Response.hs
@@ -55,5 +55,4 @@ parseBody body =
 
 -- | Lift function handling status code and body into a responder.
 basicResponder :: (Int -> BL.ByteString -> a) -> Responder m a
-basicResponder f _ (Response (Status code _) _ _ body) =
-  f code body
+basicResponder f _ r = f (statusCode (responseStatus r)) (responseBody r)


### PR DESCRIPTION
There were a few changes I had to make:
1. Request no longer has a public constructor, so pattern matching doesn't work
2. insertCookiesIntoRequest is now in Network.HTTP.Conduit.Internal. This may mean it is on it's way out; I don't know.
3. checkStatus now takes 3 arguments; it seemed like the place in Core that it was used, the intention was to ignore all of them, so I added another const.
