### PR TITLE
Allow using tls 1.3.*

### DIFF
--- a/network-api-support.cabal
+++ b/network-api-support.cabal
@@ -37,7 +37,7 @@ Library
                     , http-client-tls               >= 0.2.1.1    && < 0.3
                     , text                          >= 0.11       && < 1.3
                     , time                          == 1.*
-                    , tls                           == 1.2.*
+                    , tls                           >= 1.2.0      && < 1.4
 
   GHC-Options:
                     -Wall -fno-warn-orphans


### PR DESCRIPTION
Relaxed the upper version bound on the tls library to allow building against the current 1.3.* version.