### PR TITLE
raise http-types upper bound

### DIFF
--- a/network-api-support.cabal
+++ b/network-api-support.cabal
@@ -33,7 +33,7 @@ Library
                   , attoparsec                    >= 0.10       && < 0.14
                   , bytestring                    >= 0.9.1.5    && < 0.11
                   , case-insensitive              >= 0.2        && < 1.3
-                  , http-types                    >= 0.6        && < 0.10
+                  , http-types                    >= 0.6        && < 0.13
                   , http-client                   >= 0.2.2.2    && < 0.6
                   , http-client-tls               >= 0.2.1.1    && < 0.4
                   , text                          >= 0.11       && < 1.3


### PR DESCRIPTION
I haven't figured out how to build the `test` or `demo` projects, but the library seems to build just fine with `http-types` version 0.11.