### PR TITLE
Update tls dependency

### DIFF
--- a/network-api-support.cabal
+++ b/network-api-support.cabal
@@ -35,7 +35,7 @@ Library
                   , http-client-tls               >= 0.2.1.1    && < 0.4
                   , text                          >= 0.11       && < 1.3
                   , time                          == 1.*
-                  , tls                           >= 1.2.0      && < 1.5
+                  , tls                           >= 1.2.0      && < 1.6
 
 
   GHC-Options:


### PR DESCRIPTION
I'm not sure if this breaks anything. But it would be good to use the latest version of TLS.