### PR TITLE
Relax dependencies and support newer attoparsec

### DIFF
--- a/network-api-support.cabal
+++ b/network-api-support.cabal
@@ -26,16 +26,16 @@ Source-Repository   head
 Library
   Build-Depends:
                     base                          >= 3          && < 6
-                  , aeson                         >= 0.5        && < 2
-                  , attoparsec                    >= 0.10       && < 0.14
-                  , bytestring                    >= 0.9.1.5    && < 0.11
+                  , aeson                         >= 0.5        && < 2.1
+                  , attoparsec                    >= 0.10       && < 0.15
+                  , bytestring                    >= 0.9.1.5    && < 0.12
                   , case-insensitive              >= 0.2        && < 1.3
                   , http-types                    >= 0.6        && < 0.13
-                  , http-client                   >= 0.2.2.2    && < 0.6
+                  , http-client                   >= 0.2.2.2    && < 0.8
                   , http-client-tls               >= 0.2.1.1    && < 0.4
                   , text                          >= 0.11       && < 1.3
                   , time                          == 1.*
-                  , tls                           >= 1.2.0      && < 1.5
+                  , tls                           >= 1.2.0      && < 1.6
 
 
   GHC-Options:

--- a/network-api-support.cabal
+++ b/network-api-support.cabal
@@ -9,7 +9,7 @@ Synopsis:           Toolkit for building http client libraries over Network.Http
 Category:           Network APIs
 Homepage:           https://github.com/markhibberd/network-api-support
 Bug-reports:        https://github.com/markhibberd/network-api-support/issues
-Cabal-Version:      >= 1.8
+Cabal-Version:      >= 1.10
 Build-Type:         Simple
 Tested-With:        GHC == 7.10.3, GHC == 8.0.2
 Description:

--- a/src/Network/Api/Support/Response.hs
+++ b/src/Network/Api/Support/Response.hs
@@ -11,7 +11,10 @@ module Network.Api.Support.Response (
 import Control.Applicative
 #endif
 
+#if ! MIN_VERSION_attoparsec(0,14,0)
 import qualified Data.ByteString as B
+#endif
+
 import qualified Data.ByteString.Lazy as BL
 import Data.Attoparsec.Lazy
 import Data.Aeson
@@ -57,7 +60,11 @@ parseBodyWith body pHandler dHandler sHandler =
 -- | Parse and decode body.
 parseBody :: FromJSON a => BL.ByteString -> JsonResult a
 parseBody body =
+#if MIN_VERSION_attoparsec(0,14,0)
+  case parseOnly json body of
+#else
   case parseOnly json (B.concat . BL.toChunks $ body) of
+#endif
     Left msg -> ParseError . pack $ msg
     Right j -> case fromJSON j of
       (Error msg') -> DecodeError . pack $ msg'

--- a/src/Network/Api/Support/Response.hs
+++ b/src/Network/Api/Support/Response.hs
@@ -44,7 +44,7 @@ instance Applicative JsonResult where
    (DecodeError err) <*> _ = DecodeError err
 
 instance Monad JsonResult where
-  return = JsonSuccess
+  return = pure
   (ParseError t) >>= _ = ParseError t
   (DecodeError t) >>= _ = DecodeError t
   (JsonSuccess a) >>= f = f a


### PR DESCRIPTION
This relaxes the restrictive upper bounds and adapts to a small API change in `attoparsec-0.14`.