### PR TITLE
Increase upper bounds, support newer `aeson`

### DIFF
--- a/network-api-support.cabal
+++ b/network-api-support.cabal
@@ -23,19 +23,31 @@ Source-Repository   head
   Type:             git
   Location:         https://github.com/markhibberd/network-api-support.git
 
+flag use-attoparsec-aeson
+  description: Depend on Data.Aeson.Parser from attoparsec-aeson
+  default: True
+  manual: False
+
 Library
   Build-Depends:
                     base                          >= 3          && < 6
-                  , aeson                         >= 0.5        && < 2.1
                   , attoparsec                    >= 0.10       && < 0.15
                   , bytestring                    >= 0.9.1.5    && < 0.12
                   , case-insensitive              >= 0.2        && < 1.3
                   , http-types                    >= 0.6        && < 0.13
                   , http-client                   >= 0.2.2.2    && < 0.8
                   , http-client-tls               >= 0.2.1.1    && < 0.4
-                  , text                          >= 0.11       && < 1.3
-                  , time                          == 1.*
-                  , tls                           >= 1.2.0      && < 1.6
+                  , text                          >= 0.11       && < 2.2
+                  , time                          >= 1.0        && < 1.15
+                  , tls                           >= 1.2.0      && < 2.2
+
+  if flag(use-attoparsec-aeson)
+    Build-Depends:
+                    aeson                         >= 2.2        && < 2.3
+                  , attoparsec-aeson              >= 2.1        && < 2.3
+  else
+    Build-Depends:
+                    aeson                         >= 0.5        && < 2.2
 
 
   GHC-Options:

--- a/network-api-support.cabal
+++ b/network-api-support.cabal
@@ -56,6 +56,9 @@ Library
   Hs-Source-Dirs:
                     src
 
+  default-language:
+                    Haskell2010
+
   Exposed-Modules:
                     Network.Api.Support
                     Network.Api.Support.Core
@@ -79,9 +82,7 @@ Test-suite test
                     Network.Api.Support.Tests
 
   Ghc-Options:
-                    -O2
                     -Wall
-                    -fhpc
                     -fwarn-tabs
 
   Build-Depends:

--- a/src/Network/Api/Support/Response.hs
+++ b/src/Network/Api/Support/Response.hs
@@ -15,6 +15,10 @@ import Control.Applicative
 import qualified Data.ByteString as B
 #endif
 
+#if MIN_VERSION_aeson(2,2,0)
+import Data.Aeson.Parser (json)
+#endif
+
 import qualified Data.ByteString.Lazy as BL
 import Data.Attoparsec.Lazy
 import Data.Aeson


### PR DESCRIPTION
Note that this includes the newer changes from @adamgundry's `relax-deps` branch that were previously merged in <https://github.com/markhibberd/network-api-support/pull/29>.

- https://github.com/markhibberd/network-api-support/compare/master...adamgundry:network-api-support:relax-deps